### PR TITLE
Expose as a Go module with //go:embed FS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/webrpc/gen-dart
+
+go 1.16


### PR DESCRIPTION
This will let us import the templates and bake them directly into `webrpc-gen` tool.